### PR TITLE
Add Store#remove and update Store#add to update existing models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   `Store`.
 * Breaking change: `Store.where` returns array of matching models instead of
   array of model ids.
+* `Store#add` updates existing models instead of overwriting them
+* Add `Store#remove` method to remove a model from the store without persistence
 
 ## v0.8.0 (2014-06-09)
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,34 @@ model.destroy(); // DELETE request to model.path()
 Persisting models with associations does not create, update, or destroy any of
 the associated models.
 
+### Adding and Removing Records without Persistence
+
+Records can be added to or removed from the store without making a call to
+`#find` or `#destroy`:
+
+```javascript
+var store = new Store(adapter, {
+  'Post': Post
+});
+
+// instantiates a Post model with existing attributes
+var post = store.add('posts', { id: 42, body: 'Lorem ipsum' });
+// removes a Post model that has already been destroyed or should not be used
+store.remove(post);
+```
+
+Calling `#add` with new attributes for a model that already exists updates the
+existing model attributes instead of overwriting them:
+
+```javascript
+store.add('posts', { id: 42, body: 'Lorem ipsum' });
+store.add('posts', { id: 42, group: 'beta' });
+
+var post = store.get('posts', 42);
+post.get('body');  // returns 'Lorem ipsum'
+post.get('group'); // return 'beta'
+```
+
 ### Relating Records
 
 * There is no `belongsTo` relation. Only `hasOne` or `hasMany` currently.

--- a/lib/Store.js
+++ b/lib/Store.js
@@ -31,9 +31,14 @@ merge(Store.prototype, Events, {
 
   add: function(namespace, object) {
     var bucket = getBucket(this, namespace),
-        model  = vivify(this, namespace, object);
+        model  = this.get(namespace, object.id);
 
-    bucket[object.id] = model;
+    if (!!model) {
+      model.set(object);
+    } else {
+      model = vivify(this, namespace, object)
+      bucket[object.id] = model;
+    }
 
     return model;
   },
@@ -96,17 +101,24 @@ merge(Store.prototype, Events, {
     return self;
   },
 
-  destroy: function(model) {
+  remove: function(model) {
     var namespace = model.namespace,
         bucket    = getBucket(this, namespace),
-        prop      = String(model.id),
-        self      = this;
+        prop      = String(model.id);
 
-    self.buckets[namespace] = without(bucket, prop);
+    this.buckets[namespace] = without(bucket, prop);
+
+    return this;
+  },
+
+  destroy: function(model) {
+    var self = this;
+
+    this.remove(model);
 
     return this.adapter.destroy(model)
       .then(function() {
-        emitEvent(self, namespace, ACTIONS.destroy, model);
+        emitEvent(self, model.namespace, ACTIONS.destroy, model);
       });
   },
 


### PR DESCRIPTION
- Enables removal of models from the store without persistence
- Allows `Store#add` to be called on an existing model without overwriting its attributes
