### PR TITLE
Optimize Store#where and #parseObjects

### DIFF
--- a/lib/Store.js
+++ b/lib/Store.js
@@ -157,7 +157,7 @@ function collectMatches(bucket, props) {
     }
 
     if (match) {
-      memo = memo.concat(model);
+      memo.push(model);
     }
 
     return memo;
@@ -166,8 +166,7 @@ function collectMatches(bucket, props) {
 
 function collectAddedModels(store, namespace, values) {
   return values.reduce(function(memo, value) {
-    memo = memo.concat(store.add(namespace, value));
-
+    memo.push(store.add(namespace, value));
     return memo;
   }, []);
 }


### PR DESCRIPTION
Array#concat, while more efficient for joining two arrays, allocates a new array on each call and thus is inefficient when done in iteration over large numbers of objects. Instead, we can use Array#push, as we don't mind mutating our accumulator. This quick benchmark script demonstrates the improvement:

``` javascript
  var items = _.fill(Array(10000), 1)

  console.time("concat");
  _.reduce(items, function(res, i) { return res.concat(i); }, []);
  console.timeEnd("concat");

  console.time("push");
  var arr = [];
  _.forEach(items, function(i) { arr.push(i); });
  console.timeEnd("push");
```

Output:

```
 concat: 895.499ms
 push: 1.484ms
```

Empirically, in Efflux, this drops the runtime of `Mission#resources` with 3500 snippets from 131ms to 1.3ms.
