### PR TITLE
Support clear/0, for fully purging all namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,16 @@ post.get('body');  // returns 'Lorem ipsum'
 post.get('group'); // return 'beta'
 ```
 
+During testing or in certain production situations you may want clear all, or
+part of the store. For that, there is `clear`:
+
+```javascript
+store.clear('posts'); // all models in the posts namespace
+store.clear(); // all models in all namespaces
+```
+
+Clearing is only a local operation and doesn't make any external requests.
+
 ### Relating Records
 
 * There is no `belongsTo` relation. Only `hasOne` or `hasMany` currently.

--- a/lib/Store.js
+++ b/lib/Store.js
@@ -90,7 +90,11 @@ merge(Store.prototype, Events, {
   },
 
   clear: function(namespace) {
-    this.buckets = without(this.buckets, namespace);
+    if (namespace === undefined) {
+      this.buckets = {};
+    } else {
+      this.buckets = without(this.buckets, namespace);
+    }
 
     return this;
   },

--- a/test/store_test.js
+++ b/test/store_test.js
@@ -108,6 +108,18 @@ describe('Store', function() {
       expect(store.buckets.tags).not.to.exist;
       expect(store.all('tags')).to.be.empty;
     });
+
+    it('removes all models in all namespaces without an argument', function() {
+      var store = new Store();
+
+      store.add('tags', { id: 100 });
+      store.add('rags', { id: 101 });
+
+      store.clear();
+
+      expect(store.buckets.rags).not.to.exist;
+      expect(store.buckets.tags).not.to.exist;
+    });
   });
 
   describe('#some', function() {


### PR DESCRIPTION
Avoid test teardown that needs to be aware of all namepsaces.