### PR TITLE
Compact the array returned by Store#some

### DIFF
--- a/lib/Store.js
+++ b/lib/Store.js
@@ -1,5 +1,6 @@
 /* @flow weak */
 
+var compact     = require('./utils/compact');
 var inflector   = require('./utils/inflector');
 var merge       = require('./utils/merge');
 var without     = require('./utils/without');
@@ -69,9 +70,9 @@ merge(Store.prototype, Events, {
     var bucket = getBucket(this, namespace);
 
     if (ids && ids.length) {
-      return ids.map(function(id) {
+      return compact(ids.map(function(id) {
         return bucket[id];
-      });
+      }));
     } else {
       return [];
     }

--- a/test/store_test.js
+++ b/test/store_test.js
@@ -76,8 +76,8 @@ describe('Store', function() {
 
   describe('#find', function() {
     it('retrieves a stored object', function() {
-      var store  = new Store(),
-          object = { id: 100 };
+      var store  = new Store();
+      var object = { id: 100 };
 
       store.add('tags', object);
 
@@ -90,7 +90,6 @@ describe('Store', function() {
   describe('#all', function() {
     it('retrieves all objects stored within a namespace', function() {
       var store = new Store();
-
       store.add('tags', { id: 100 });
 
       expect(store.all('tags')).to.have.length(1);
@@ -124,14 +123,19 @@ describe('Store', function() {
 
   describe('#some', function() {
     it('retrieves each from a list of ids', function() {
-      var store   = new Store(),
-          objectA = { id: 100 },
-          objectB = { id: 101 };
-
-      store.add('tags', objectA);
-      store.add('tags', objectB);
+      var store = new Store();
+      store.add('tags', { id: 100 });
+      store.add('tags', { id: 101 });
 
       expect(store.some('tags', [100, 101])).to.have.length(2);
+    });
+
+    it('does not retrieve undefined items', function() {
+      var store = new Store();
+      store.add('tags', { id: 100 });
+      store.add('tags', { id: 102 });
+
+      expect(store.some('tags', [100, 101])).to.have.length(1);
     });
   });
 


### PR DESCRIPTION
It was possible for Relation#all (which uses Store#some under the hood) to return an array with `undefined` in it. If one of the `ids` passed to `some` cannot be found in the store, that item will be pruned from the array that will be returned.