### PR TITLE
Add optional catcher to Adapter

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  node:
+    version: 8.9.1

--- a/lib/Adapter.js
+++ b/lib/Adapter.js
@@ -8,6 +8,7 @@ var Adapter = function(options) {
 
   this.headers = options.headers || {};
   this.host    = options.host    || '';
+  this.catcher = options.catcher;
 };
 
 merge(Adapter.prototype, {
@@ -31,11 +32,14 @@ merge(Adapter.prototype, {
 function buildRequest(adapter, method, path) {
   var url     = adapter.host + path,
       request = new Request(method, url),
-      headers = adapter.headers;
+      headers = adapter.headers,
+      catcher = adapter.catcher;
 
   Object.keys(headers).forEach(function(key) {
     request.set(key, headers[key]);
   });
+
+  if (catcher) request.catch(catcher)
 
   return request;
 }

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "es6-promise": "^2.0.0",
-    "proquest": "^0.3.0"
+    "es6-promise": "^4.2.4",
+    "proquest": "^0.4.0"
   },
   "bugs": {
     "url": "https://github.com/dscout/immunid/issues"

--- a/package.json
+++ b/package.json
@@ -28,13 +28,17 @@
   },
   "homepage": "https://github.com/dscout/immunid",
   "devDependencies": {
-    "chai": "^1.9.1",
+    "browserify": "^16.2.2",
+    "chai": "^4.0.0",
     "jshint": "^2.5.1",
-    "karma": "^0.12.24",
-    "karma-browserify": "^1.0.0",
-    "karma-chai-sinon": "^0.1.4",
-    "karma-firefox-launcher": "^0.1.3",
-    "karma-mocha": "^0.1.9",
-    "sinon": "^1.12.2"
+    "karma": "^2.0.0",
+    "karma-browserify": "^5.3.0",
+    "karma-chai-sinon": "^0.1.5",
+    "karma-firefox-launcher": "^1.1.0",
+    "karma-mocha": "^1.3.0",
+    "mocha": "^5.2.0",
+    "sinon": "^4.1.6",
+    "sinon-chai": "^3.2.0",
+    "watchify": "^3.11.0"
   }
 }

--- a/test/adapter_test.js
+++ b/test/adapter_test.js
@@ -47,6 +47,25 @@ describe('Adapter', function() {
     });
   });
 
+  it('catches failed requests with provided catcher', function(done) {
+    server.respondWith('GET', '/comments/1', [
+      401, { 'Content-Type': 'application/json' }, ''
+    ]);
+
+    var catcher = sinon.spy();
+    var adapter = new Adapter({ catcher });
+
+    adapter
+      .read({ path: function() { return '/comments/1' } })
+      .catch(function(response) {
+        expect(catcher).to.be.calledOnce;
+
+        done();
+      });
+
+    server.respond();
+  })
+
   describe('#read', function() {
     it('peforms a GET request with object URL', function(done) {
       server.respondWith('GET', '/comments/1', [

--- a/test/adapter_test.js
+++ b/test/adapter_test.js
@@ -35,9 +35,7 @@ describe('Adapter', function() {
 
       adapter.read({ path: function() { return '/comments' } });
 
-      expect(request.requestHeaders).to.eql({
-        'Accept': 'application/json'
-      });
+      expect(request.requestHeaders.Accept).to.eq('application/json');
     });
 
     it('prepends the host to the path', function() {


### PR DESCRIPTION
Proquest accepts an optional "catcher" function that is called when requests fail (i.e. return a `4xx` or `5xx` response). This PR updates Immunid's `Adapter` class to accept a catcher in the constructor and configure the Proquest `request` object with it.

This will be used to add global handling to `401` responses to handle session expiration in v3 interfaces.

Note: It seems that the last time Immunid was worked on, the engineer(s) had a number of testing dependencies installed globally. I've updated `package.json` with the missing dev dependencies that are needed to run the test suite.